### PR TITLE
fix wrong pointer comparison.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -649,7 +649,7 @@ int main ( int argc, char ** argv )
         exit(1);
       }
       else
-      if (endptr != '\0') {
+      if (*endptr != '\0') {
         printf("Bad argument for --rng-seed '%s'\n",arg);
         exit(1);
       }
@@ -664,7 +664,7 @@ int main ( int argc, char ** argv )
         exit(1);
       }
       else
-      if (endptr != '\0') {
+      if (*endptr != '\0') {
         printf("Bad argument for --rng-seed '%s'\n",arg);
         exit(1);
       }


### PR DESCRIPTION
Please review and merge.

```
main.cpp: In function ‘int main(int, char**)’:
main.cpp:652:21: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
       if (endptr != '\0') {
                     ^~~~
main.cpp:667:21: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
       if (endptr != '\0') {
                     ^~~~
```