### PR TITLE
Add FanomHash (WIP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,9 @@ ENDIF()
 IF(EXISTS "./funny_hash.h")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_FUNNY_HASH")
 ENDIF()
+IF(EXISTS "./fanom_hash.h")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_FANOM_HASH")
+ENDIF()
 add_library(SMHasherSupport
   AvalancheTest.cpp
   Bitslice.cpp

--- a/Hashes.cpp
+++ b/Hashes.cpp
@@ -500,3 +500,21 @@ void lua_v53_string_hash (const void *key, int len, const void *seed, void *out)
     h ^= ((h<<5) + (h>>2) + str[len-1]);
   *((uint32_t*)out)=h;
 }
+
+#ifdef HAVE_FANOM_HASH
+// Fast non-multiplicative hash function.
+// https://github.com/funny-falcon/fanom_hash
+#include "fanom_hash.h"
+void
+fanom_hash64_seed_state_test(int seed_bits, const void * seed, void *state)
+{
+    memcpy(state,seed,seed_bits/8);
+}
+
+void
+fanom_hash64_with_state_test(const void *key, int len, const void * state, void *out)
+{
+    uint64_t *s64 = (uint64_t *)state;
+  *(uint64_t *) out = fanom64_string_hash2(key, len, s64[0], s64[1] ^ 1);
+}
+#endif

--- a/Hashes.h
+++ b/Hashes.h
@@ -268,3 +268,9 @@ funny_hash64_2_with_state_test(const void *key, int len, const void * state, voi
 }
 #endif
 
+#ifdef HAVE_FANOM_HASH
+void fanom_hash64_seed_state_test(int seed_bits, const void * seed, void *state);
+
+void fanom_hash64_with_state_test(const void *key, int len, const void * state, void *out);
+#endif
+

--- a/main.cpp
+++ b/main.cpp
@@ -192,6 +192,12 @@ HashInfo g_hashes[] =
     funny_hash64_2_seed_state_test, funny_hash64_2_with_state_test },
 #endif
 
+#ifdef HAVE_FANOM_HASH
+  { "FanomHash64", "Funny Falcon",
+    128, 128, 64, 0xF43E774E,
+    fanom_hash64_seed_state_test, fanom_hash64_with_state_test },
+#endif
+
 
   // MurmurHash2
   { "Murmur2", "MurmurHash2 for x86, 32-bit",


### PR DESCRIPTION
https://github.com/funny-falcon/fanom_hash

Fast non-multiplicative hash with 128bit seed and internal 256bit state.
Passes all tests.

It is declared as having 128bit of state because only 128bit are seeded at a start.
Should it be declared as having 128bit state or 256 bit state?